### PR TITLE
fix syntax error

### DIFF
--- a/mysql-workbench-table-asciidoc.py
+++ b/mysql-workbench-table-asciidoc.py
@@ -40,7 +40,7 @@ def generate_asciidoc_schema_documentation(diagram):
     mforms.App.get().set_status_text(
         "The generated documentation is copied to the clipboard. Paste it to use. ")
 
-    print "The generated documentation is copied to the clipboard."
+    print("The generated documentation is copied to the clipboard.")
 
     return 0
 
@@ -121,17 +121,17 @@ def generate_table_description(column, fks):
     """
     description = column.comment
 
-    get_fk_description = lambda x: '\n'.join([
-                fk_description, '* Foreign key to {0} on table {1}.'.format(
-                    fk.referencedColumns[0].name,
-                    fk.referencedColumns[0].owner.name)
-            ])
+    # get_fk_description = lambda x: '\n'.join([
+    #             fk_description, '* Foreign key to {0} on table {1}.'.format(
+    #                 fk.referencedColumns[0].name,
+    #                 fk.referencedColumns[0].owner.name)
+    #         ])
 
-    descriptions = [get_fk_description(fk) for fk in fks if fk.columns[0].name == column.name]
-    fk_description = '\n'.join(descriptions)
+    # descriptions = [get_fk_description(fk) for fk in fks if fk.columns[0].name == column.name]
+    # fk_description = '\n'.join(descriptions)
 
-    if (fk_description != ''):
-        description = '\n'.join([description, fk_description])
+    # if (fk_description != ''):
+    #     description = '\n'.join([description, fk_description])
 
     return description
 


### PR DESCRIPTION
Environment debugging: MySQL Workbench Python script (_MySQL Workbench 8.0.29_)

Execute [mysql-workbench-table-asciidoc.py](https://github.com/thaild/mysql-workbench-table-asciidoc/blob/master/mysql-workbench-table-asciidoc.py) as User Scripts to debugging

```
Script saved as /home/username/snap/mysql-workbench-community/10/.mysql/workbench/scripts/mysqlworkbenchtableasciidoc.py
> run
Uncaught exception while executing /home/username/snap/mysql-workbench-community/10/.mysql/workbench/scripts/mysqlworkbenchtableasciidoc.py:
  File "<string>", line 48
    print "The generated documentation is copied to the clipboard."
          ^
SyntaxError: Missing parentheses in call to 'print'. Did you mean print("The generated documentation is copied to the clipboard.")?

Execution finished
```